### PR TITLE
Raccourcir les codes couleurs hexadécimaux

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -114,6 +114,11 @@ class CSSLisible {
         $_SESSION['CSSLisible']['options'][$option] = $value;
     }
 
+    public function short_hex_color_values($matches) {
+        array_shift($matches);
+        return implode($matches);
+    }
+
 	private function compress_css($css_to_compress,$lvl=0){
 		
         $css_to_compress = strip_tags($css_to_compress);
@@ -130,6 +135,10 @@ class CSSLisible {
         // Ecriture trop lourde
         $css_to_compress = str_replace(';;', ';', $css_to_compress);
 		$css_to_compress = preg_replace('#:0(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm);#', ':0;', $css_to_compress);
+		
+		// Simplification des codes couleurs hexadécimaux
+		$css_to_compress = preg_replace_callback('#(:[^;]*\#)([a-fA-F\d])\2([a-fA-F\d])\3([a-fA-F\d])\4([^;]*;)#', array(CSSLisible, 'short_hex_color_values'), $css_to_compress);
+		
 		
 		if($lvl>0){
 	        $css_to_compress = str_replace(';}', '}', $css_to_compress);


### PR DESCRIPTION
Hello,

Un petit ajout pour simplifier les codes hexa et gagner encore un peu dans la compression.
L'expression régulière matche les codes couleurs ayant 3 caractères doublés comme #aabbcc pour les remplacer par leur version simplifiée, #abc ici.

Pas grand chose à dire de plus :)

Quelques cas de tests :
- border: #cccccc 1px solid;
- border: 1px #cccccc solid;
- border: 1px solid #cccccc;
- color: #000000;
- color: #aabbcc;
- color: #112233;
- color: #211233;
- color: #a12aa3;
