### PR TITLE
Suppression des décimales inutiles

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -163,7 +163,7 @@ class CSSLisible {
 		$css_to_compress = str_replace(';;', ';', $css_to_compress);
 		$css_to_compress = preg_replace('#:0(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm);#', ':0;', $css_to_compress);
 		// Suppression des décimales inutiles
-		$css_to_compress = preg_replace('#:([^;]*[1-9]+[0-9]*)\.0+(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm)([^;]*);#', ':$1$2$3;', $css_to_compress);
+		$css_to_compress = preg_replace('#:(([^;]*[0-9]*)\.|([^;]*[0-9]*\.[0-9]+))0+(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm)([^;]*);#', ':$2$3$4$5;', $css_to_compress);
 		
 		// Simplification des codes couleurs hexadécimaux
 		$css_to_compress = preg_replace_callback('#(:[^;]*\#)([a-fA-F\d])\2([a-fA-F\d])\3([a-fA-F\d])\4([^;]*;)#', array($this, 'short_hex_color_values'), $css_to_compress);


### PR DESCRIPTION
Hello,

En récupérant un fichier CSS je suis tombé sur des décimales inutiles, autrement dit ce genre de choses : "3.0em".
Et je me suis dit que ça pouvait être intéressant de les enlever via CSSLisible ... même si ça peut être anecdotique.

Voici les cas de tests vérifiés :

```
.test {
    margin: 0em;
    margin: 0.2em;
    margin: 12.05em;
    margin: 888.0em;
    margin: 12.050em;
    margin: 0.20em;
    border: 3.0px solid red;
    border: solid 3.0px red;
    border: solid red 3.0px;
}
```

et ce qui produit :

```
.test {
    margin: 0;
    margin: 0.2em;
    margin: 12.05em;
    margin: 888em;
    margin: 12.05em;
    margin: 0.2em;
    border: 3px solid red;
    border: solid 3px red;
    border: solid red 3px;
}
```
