### PR TITLE
Amélioration de la simplification des valeurs nulles

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -169,7 +169,7 @@ class CSSLisible {
 
 		// Ecriture trop lourde
 		$css_to_compress = str_replace(';;', ';', $css_to_compress);
-		$css_to_compress = preg_replace('#:0(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm);#', ':0;', $css_to_compress);
+		$css_to_compress = preg_replace('#([\s]|:)0(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm)#', '${1}0', $css_to_compress);
 		// Suppression des décimales inutiles
 		$css_to_compress = preg_replace('#:(([^;]*[0-9]*)\.|([^;]*[0-9]*\.[0-9]+))0+(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm)([^;]*);#', ':$2$3$4$5;', $css_to_compress);
 		


### PR DESCRIPTION
Petit correctif rapide pour supprimer partout les unités des valeurs nulles.
Auparavant seules les valeurs nulles uniques (de type ":0px;") étaient concernées mais avec cette modification toutes les valeurs nulles sont prises en comptes, même dans le cas des raccourcis CSS.

Exemples :
(la valeur de border-bottom n'a pas de sens je te l'accorde)

```
.test {
    border: 1px 0px;
    border: 0px 2px;
    border-bottom: 0px solid red;
    border-bottom: solid 0px red;
    border-bottom: solid red 0px;
    border-width: 0em;
    border-width: 10px;
}
```

ce qui génère :

```
.test {
    border : 1px 0;
    border : 0 2px;
    border-bottom : 0 solid red;
    border-bottom : solid 0 red;
    border-bottom : solid red 0;
    border-width : 0;
    border-width : 10px;
}
```
