### PR TITLE
Pour gagner encore quelques octets en compression...

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -308,6 +308,10 @@ class CSSLisible {
 		}
 	}
 
+	public function identify_and_short_hex_color_values($css_to_compress) {
+		return preg_replace_callback('#(:[^;]*\#)([a-fA-F\d])\2([a-fA-F\d])\3([a-fA-F\d])\4([^;]*;)#', array($this, 'short_hex_color_values'), $css_to_compress);
+	}
+
 	public function short_hex_color_values($matches) {
 		array_shift($matches);
 		return implode($matches);
@@ -320,6 +324,8 @@ class CSSLisible {
 		if($this->get_option('tout_compresse')){
 			// 0.1em => .1em
 			$css_to_compress = preg_replace('#(\s|:)0\.(([0-9]*)(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm))#', '$1.$2', $css_to_compress);
+			// Simplification des codes couleurs hexadécimaux
+			$css_to_compress = $this->identify_and_short_hex_color_values($css_to_compress);
 			// Suppression des commentaires
 			$css_to_compress = preg_replace('!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $css_to_compress);
 		}
@@ -343,7 +349,7 @@ class CSSLisible {
 			$css_to_compress = $this->convert_colors($css_to_compress);
 		}
 		// Simplification des codes couleurs hexadécimaux
-		$css_to_compress = preg_replace_callback('#(:[^;]*\#)([a-fA-F\d])\2([a-fA-F\d])\3([a-fA-F\d])\4([^;]*;)#', array($this, 'short_hex_color_values'), $css_to_compress);
+		$css_to_compress = $this->identify_and_short_hex_color_values($css_to_compress);
 		
 		// Suppression des derniers espaces inutiles
 		$css_to_compress = preg_replace('#([\s]*)([\{\}\:\;\(\)\,])([\s]*)#', '$2', $css_to_compress);


### PR DESCRIPTION
Hello,

Petites modifications mineures pour optimiser la compression du code :
- Suppression des zéros inutiles pour les valeurs inférieures à 1 : 0.2em devient .2em
- Simplification des codes couleurs hexa

Pour vérifier le premier point :

```
.test {
    margin:0.1em;
    margin:0.02em;
    margin: 0.3em;
    margin: 10em;
    margin: 0.4em 10em;
    margin: 10em 0.5em;
    margin: 0.6em 10em 0.7em;
    margin: 0.8em 0.9em 0.10em;
    margin: 0.11em 0.12em 0.13em 0.14em;
}
```

Bon ok je n'ai pas été super inspiré pour nommer la méthode qui factorise le preg_match de simplification des codes hexa. Tu peux en changer si tu veux :)
