### PR TITLE
Quelques optimisations : valeurs négatives, !important et décimales nulles

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -356,7 +356,7 @@ class CSSLisible {
 		$css_to_compress = str_replace(';;', ';', $css_to_compress);
 		$css_to_compress = preg_replace('#([\s]|:)0(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm)#', '${1}0', $css_to_compress);
 		// Suppression des décimales inutiles
-		$css_to_compress = preg_replace('#:(([^;]*-?[0-9]*)\.|([^;]*-?[0-9]*\.[0-9]+))0+(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm)([^;]*);#', ':$2$3$4$5;', $css_to_compress);
+		$css_to_compress = preg_replace('#:(([^;]*-?[0-9]*)\.|([^;]*-?[0-9]*\.[1-9]+))0+(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm)([^;]*);#', ':$2$3$4$5;', $css_to_compress);
 		
 		// Passage temporaire des codes hexa de 3 en 6 caractères (pour les conversions de couleurs)
 		$css_to_compress = preg_replace('#(:[^;]*\#)([a-fA-F\d])([a-fA-F\d])([a-fA-F\d])([^;]*;)#', '$1$2$2$3$3$4$4$5', $css_to_compress);


### PR DESCRIPTION
Dans la lignée du PR précédent voici quelques ajustements.

Les regexp de raccourcis deviennent un peu moins restrictives pour pouvoir gérer les valeurs négatives et les éventuels "!important".
J'en profite aussi pour inclure une toute petite modif sur la suppression des décimales inutiles. Cela permettra de ne pas retirer seulement le dernier 0 mais tous les derniers.

De quoi tester :

```
.test {
    margin: -1px -1px -1px -1px;
    margin: 1px 1px 1px 1px !important;
    padding: -1px -2px -1px -2px;
    padding: 1px 2px 1px 2px !important;
    border-width: -1px -2px -3px -2px;
    border-width: 1px 2px 3px 2px !important;
    border-radius: -1px -1px -1px -1px / -2px -2px -2px -2px;
    border-radius: 1px 1px 1px 1px / 2px 2px 2px 2px !important;
    border-radius: -1px -2px -1px -2px / -2px -3px -2px -3px;
    border-radius: 1px 2px 1px 2px / 2px 3px 2px 3px !important;
    border-radius: -1px -2px -3px -2px / -2px -3px -4px -3px;
    border-radius: 1px 2px 3px 2px / 2px 3px 4px 3px !important;
    -moz-border-radius: -1px / -1px;
    -moz-border-radius: 1px / 1px !important;
}
.test {
    margin: 10.0em;
    margin: -10.0em;
    margin: 0.210em;
    margin: 10.200em;
    margin: 0.200em;
    margin: -0.200em;
}
```
