### PR TITLE
Corrections sur les conversions de couleurs

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -365,7 +365,7 @@ class CSSLisible {
 		$css_to_compress = preg_replace('#:(([^;]*-?[0-9]*)\.|([^;]*-?[0-9]*\.[1-9]+))0+(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm)([^;]*);#', ':$2$3$4$5;', $css_to_compress);
 		
 		// Passage temporaire des codes hexa de 3 en 6 caractères (pour les conversions de couleurs)
-		$css_to_compress = preg_replace('#(:[^;]*\#)([a-fA-F\d])([a-fA-F\d])([a-fA-F\d])([^;]*;)#', '$1$2$2$3$3$4$4$5', $css_to_compress);
+		$css_to_compress = preg_replace('#(:[^;]*\#)([a-fA-F\d])([a-fA-F\d])([a-fA-F\d])([^a-fA-F\d;]*;)#', '$1$2$2$3$3$4$4$5', $css_to_compress);
 		// Simplification des codes RGB et RGBA utilisant des % en valeurs chiffrées
 		$css_to_compress = preg_replace_callback('#(:[^;]*rgb\()(\d{1,3})%[\s]*,[\s]*(\d{1,3})%[\s]*,[\s]*(\d{1,3})%(\)[^;]*;)#i', array($this, 'rgb_percent2value'), $css_to_compress);
 		$css_to_compress = preg_replace_callback('#(:[^;]*rgba\()(\d{1,3})%[\s]*,[\s]*(\d{1,3})%[\s]*,[\s]*(\d{1,3})%([\s]*,[\s]*\d(\.\d+)?\)[^;]*;)#i', array($this, 'rgb_percent2value'), $css_to_compress);


### PR DESCRIPTION
Avec un peu de retard voilà de quoi corriger le bug de gestion des couleurs nommées, notamment avec "!important" (cf. #37).
Désolé je n'ai pas pu vraiment m'y mettre avant.

Par contre j'en ai profité pour corriger un bug visible à la conversion hexa vers RGB. En gros les 3 premiers caractères des codes hexa étaient doublés à tord ce qui générait un RGB + le restant du code hexa original.

Mon code de test :

```
.test-tan {
    width: auto !important;
    border: 1px solid tan !important;
    border: 1px solid tan;
    border: 1px tan solid;
    border: tan 1px solid;
    border: 1px solid TAN;
    border: 1px TAN solid;
    border: TAN 1px solid;
    color: tan;
    color: TAN !important;
    test-tan: lorem;
    test1: #abc;
    test2: #aabbcc;
}
```

_Ping @davidtw_
