### PR TITLE
Fix #39 Compression des valeurs avec décimales

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -343,7 +343,7 @@ class CSSLisible {
 
 		if($this->get_option('tout_compresse')){
 			// 0.1em => .1em
-			$css_to_compress = preg_replace('#((\s|:)-?)0\.(([0-9]*)(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm))#', '$1.$2', $css_to_compress);
+			$css_to_compress = preg_replace('#((\s|:)-?)0\.(([0-9]*)(px|em|ex|%|pt|pc|in|cm|mm|rem|vw|vh|vm))#', '$1.$3', $css_to_compress);
 			// Simplification des codes couleurs hexadécimaux
 			$css_to_compress = $this->identify_and_short_hex_color_values($css_to_compress);
 			// Simplification des valeurs à 4 paramètres chiffrés


### PR DESCRIPTION
Une petite modif pour régler le bug #39

```
p {
    margin-top: -0.8em;
    margin-right: -0.08em;
    margin-bottom: 0.2em;
    margin-left: 0.02em;
}
```

Est maintenant bien compressé en :

```
p{margin-top:-.8em;margin-right:-.08em;margin-bottom:.2em;margin-left:.02em}
```
