### PR TITLE
Correction de la traduction du slogan du site

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -2,7 +2,7 @@
 if ( !defined( 'TITRE_SITE' ) )
     define( 'TITRE_SITE', 'CSSLisible' );
 if ( !defined( 'SLOGAN_SITE' ) )
-    define( 'SLOGAN_SITE', _( 'Ordonner votre CSS et le rendre lisible' ) );
+    define( 'SLOGAN_SITE', 'Ordonner votre CSS et le rendre lisible' );
 if ( !defined( 'COOKIE_NAME' ) )
     define( 'COOKIE_NAME', 'CSSLisible' );
 if ( !defined( 'CURLOPT_USERAGENT_NAME' ) )

--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@ include DIR_SITE . '/inc/header.php';
 <html lang="<?php echo $lang; ?>">
 	<head>
 		<meta charset="utf-8"/>
-		<title><?php echo TITRE_SITE . ' - ' . SLOGAN_SITE; ?></title>
+		<title><?php echo TITRE_SITE . ' - ' . _(SLOGAN_SITE); ?></title>
 		<meta name="viewport" content="width=790" />
 		<link rel="stylesheet" href="css/main.css?t=201208181531" type="text/css" />
 	</head>
@@ -14,7 +14,7 @@ include DIR_SITE . '/inc/header.php';
 	<div id="main-container">
 		<div id="header">
 		    <?php include DIR_SITE . '/inc/tpl/lang_menu.php'; ?>
-    		<h1><?php echo TITRE_SITE . ' - ' . SLOGAN_SITE; ?></h1>
+    		<h1><?php echo TITRE_SITE . ' - ' . _(SLOGAN_SITE); ?></h1>
 		</div>
 		<form id="main-form" action="" method="post" enctype="multipart/form-data">
 
@@ -52,14 +52,14 @@ include DIR_SITE . '/inc/header.php';
 		</form>
 	</div>
 	<div id="footer">
-	    <a target="_blank" href="https://github.com/Darklg/CSSLisible/blob/master/README.md"><?php echo _('Documentation'); ?></a> - 
-		<?php echo _('Source disponible sur'); ?> 
-		<a target="_blank" href="http://github.com/darklg/CSSLisible">Github</a> - 
-		<?php echo _('Contributeurs : '); ?> 
+	    <a target="_blank" href="https://github.com/Darklg/CSSLisible/blob/master/README.md"><?php echo _('Documentation'); ?></a> -
+		<?php echo _('Source disponible sur'); ?>
+		<a target="_blank" href="http://github.com/darklg/CSSLisible">Github</a> -
+		<?php echo _('Contributeurs : '); ?>
 		<a target="_blank" href="http://github.com/Darklg">Darklg</a>,
 		<a target="_blank" href="http://github.com/NumEricR">NumEricR</a>
 	</div>
-	
+
 	<?php
 	// Fichier conditionnel pour charger boutons like, google analytics, etc.
 	$hollow_file = realpath(DIR_SITE).'/inc/hollow-file.php';
@@ -67,9 +67,9 @@ include DIR_SITE . '/inc/header.php';
 	    include $hollow_file;
 	}
 	?>
-	
+
 	<script src="js/ZeroClipboard.min.js?1363440036"></script>
 	<script src="js/events.js?t=201208181531" type="text/javascript" charset="utf-8"></script>
-	
+
 	</body>
 </html>


### PR DESCRIPTION
Salut,

Le slogan est défini par une constante contenant l'appel à la fonction de traduction.
J'ai externalisé cet appel pour que le changement de langue permette de changer ce libellé.

Je viens de m'apercevoir que mon commit embarquait la suppression des espaces de fin de ligne (config ST). Tu peux supprimer cette partie si tu veux.

Eric
